### PR TITLE
Stand up Pelican skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# Pelican
+output/

--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ venv.bak/
 
 # Pelican
 output/
+
+# PyCharm
+.idea/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,75 @@
+PY?=python3
+PELICAN?=pelican
+PELICANOPTS=
+
+BASEDIR=$(CURDIR)
+INPUTDIR=$(BASEDIR)/content
+OUTPUTDIR=$(BASEDIR)/output
+CONFFILE=$(BASEDIR)/pelicanconf.py
+PUBLISHCONF=$(BASEDIR)/publishconf.py
+
+
+DEBUG ?= 0
+ifeq ($(DEBUG), 1)
+	PELICANOPTS += -D
+endif
+
+RELATIVE ?= 0
+ifeq ($(RELATIVE), 1)
+	PELICANOPTS += --relative-urls
+endif
+
+help:
+	@echo 'Makefile for a pelican Web site                                           '
+	@echo '                                                                          '
+	@echo 'Usage:                                                                    '
+	@echo '   make html                           (re)generate the web site          '
+	@echo '   make clean                          remove the generated files         '
+	@echo '   make regenerate                     regenerate files upon modification '
+	@echo '   make publish                        generate using production settings '
+	@echo '   make serve [PORT=8000]              serve site at http://localhost:8000'
+	@echo '   make serve-global [SERVER=0.0.0.0]  serve (as root) to $(SERVER):80    '
+	@echo '   make devserver [PORT=8000]          serve and regenerate together      '
+	@echo '   make ssh_upload                     upload the web site via SSH        '
+	@echo '   make rsync_upload                   upload the web site via rsync+ssh  '
+	@echo '                                                                          '
+	@echo 'Set the DEBUG variable to 1 to enable debugging, e.g. make DEBUG=1 html   '
+	@echo 'Set the RELATIVE variable to 1 to enable relative urls                    '
+	@echo '                                                                          '
+
+html:
+	$(PELICAN) $(INPUTDIR) -o $(OUTPUTDIR) -s $(CONFFILE) $(PELICANOPTS)
+
+clean:
+	[ ! -d $(OUTPUTDIR) ] || rm -rf $(OUTPUTDIR)
+
+regenerate:
+	$(PELICAN) -r $(INPUTDIR) -o $(OUTPUTDIR) -s $(CONFFILE) $(PELICANOPTS)
+
+serve:
+ifdef PORT
+	$(PELICAN) -l $(INPUTDIR) -o $(OUTPUTDIR) -s $(CONFFILE) $(PELICANOPTS) -p $(PORT)
+else
+	$(PELICAN) -l $(INPUTDIR) -o $(OUTPUTDIR) -s $(CONFFILE) $(PELICANOPTS)
+endif
+
+serve-global:
+ifdef SERVER
+	$(PELICAN) -l $(INPUTDIR) -o $(OUTPUTDIR) -s $(CONFFILE) $(PELICANOPTS) -p $(PORT) -b $(SERVER)
+else
+	$(PELICAN) -l $(INPUTDIR) -o $(OUTPUTDIR) -s $(CONFFILE) $(PELICANOPTS) -p $(PORT) -b 0.0.0.0
+endif
+
+
+devserver:
+ifdef PORT
+	$(PELICAN) -lr $(INPUTDIR) -o $(OUTPUTDIR) -s $(CONFFILE) $(PELICANOPTS) -p $(PORT)
+else
+	$(PELICAN) -lr $(INPUTDIR) -o $(OUTPUTDIR) -s $(CONFFILE) $(PELICANOPTS)
+endif
+
+publish:
+	$(PELICAN) $(INPUTDIR) -o $(OUTPUTDIR) -s $(PUBLISHCONF) $(PELICANOPTS)
+
+
+.PHONY: html help clean regenerate serve serve-global devserver stopserver publish 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,45 @@
-# website
-pghpython website
+# pghpython website
+
+## Stack
+
+This site is built using [Pelican](https://docs.getpelican.com/en/stable/), a static site generation framework.
+
+## Developing
+
+1. Clone this repository and change to the newly created directory:
+
+    ```shell
+    $ git clone git@github.com:pghpython/website.git  # or over HTTPS if you prefer
+    $ cd website/
+    ```
+
+1. Create and activate a virtual environment for working on this project.
+   You can use whichever tool you like (I use `pyenv`/`pyenv-virtualenv` myself, but the built-in `venv` works fine):
+
+    ```shell
+    $ python3 -m venv .venv/
+    $ source .venv/bin/activate
+    ```
+
+1. Install the dependencies:
+
+    ```shell
+    (.venv) $ pip install -r requirements.txt
+    ```
+
+1. Build and serve a local copy of the content:
+
+    ```shell
+    (.venv) $ pelican content
+    Done: Processed 0 articles, 0 drafts, 1 page, 0 hidden pages and 0 draft pages in 0.14 seconds.
+    (.venv) $ pelican --listen
+    ```
+
+    The site should now be available [on your local host](http://localhost:8000).
+
+    You can also use `make` if you prefer (you can just type `make` to see all the available options):
+
+    ```shell
+    (.venv) $ make html
+    (.venv) $ make serve
+    ```

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # pghpython website
 
+
 ## Stack
 
 This site is built using [Pelican](https://docs.getpelican.com/en/stable/), a static site generation framework.
+
 
 ## Developing
 

--- a/content/pages/home.md
+++ b/content/pages/home.md
@@ -1,0 +1,6 @@
+Title: pghpython
+Date: 2019-06-04 18:44
+
+# pghpython
+
+Welcome to pghpython!

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*- #
+from __future__ import unicode_literals
+
+AUTHOR = 'pghpython'
+SITENAME = 'pghpython'
+SITEURL = ''
+
+PATH = 'content'
+
+TIMEZONE = 'America/New_York'
+
+DEFAULT_LANG = 'en'
+
+# Feed generation is usually not desired when developing
+FEED_ALL_ATOM = None
+CATEGORY_FEED_ATOM = None
+TRANSLATION_FEED_ATOM = None
+AUTHOR_FEED_ATOM = None
+AUTHOR_FEED_RSS = None
+
+# Blogroll
+LINKS = (('Pelican', 'http://getpelican.com/'),
+         ('Python.org', 'http://python.org/'),
+         ('Jinja2', 'http://jinja.pocoo.org/'),
+         ('You can modify those links in your config file', '#'),)
+
+# Social widget
+SOCIAL = (('You can add links in your config file', '#'),
+          ('Another social link', '#'),)
+
+DEFAULT_PAGINATION = 10
+
+# Uncomment following line if you want document-relative URLs when developing
+#RELATIVE_URLS = True

--- a/publishconf.py
+++ b/publishconf.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*- #
+from __future__ import unicode_literals
+
+# This file is only used if you use `make publish` or
+# explicitly specify it as your config file.
+
+import os
+import sys
+sys.path.append(os.curdir)
+from pelicanconf import *
+
+# If your site is available via HTTPS, make sure SITEURL begins with https://
+SITEURL = ''
+RELATIVE_URLS = False
+
+FEED_ALL_ATOM = 'feeds/all.atom.xml'
+CATEGORY_FEED_ATOM = 'feeds/{slug}.atom.xml'
+
+DELETE_OUTPUT_DIRECTORY = True
+
+# Following items are often useful when publishing
+
+#DISQUS_SITENAME = ""
+#GOOGLE_ANALYTICS = ""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Markdown==3.1.1
+pelican==4.0.1

--- a/tasks.py
+++ b/tasks.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+
+import os
+import shutil
+import sys
+import datetime
+
+from invoke import task
+from invoke.util import cd
+from pelican.server import ComplexHTTPRequestHandler, RootedHTTPServer
+
+CONFIG = {
+    # Local path configuration (can be absolute or relative to tasks.py)
+    'deploy_path': 'output',
+    # Port for `serve`
+    'port': 8000,
+}
+
+@task
+def clean(c):
+    """Remove generated files"""
+    if os.path.isdir(CONFIG['deploy_path']):
+        shutil.rmtree(CONFIG['deploy_path'])
+        os.makedirs(CONFIG['deploy_path'])
+
+@task
+def build(c):
+    """Build local version of site"""
+    c.run('pelican -s pelicanconf.py')
+
+@task
+def rebuild(c):
+    """`build` with the delete switch"""
+    c.run('pelican -d -s pelicanconf.py')
+
+@task
+def regenerate(c):
+    """Automatically regenerate site upon file modification"""
+    c.run('pelican -r -s pelicanconf.py')
+
+@task
+def serve(c):
+    """Serve site at http://localhost:8000/"""
+
+    class AddressReuseTCPServer(RootedHTTPServer):
+        allow_reuse_address = True
+
+    server = AddressReuseTCPServer(
+        CONFIG['deploy_path'],
+        ('', CONFIG['port']),
+        ComplexHTTPRequestHandler)
+
+    sys.stderr.write('Serving on port {port} ...\n'.format(**CONFIG))
+    server.serve_forever()
+
+@task
+def reserve(c):
+    """`build`, then `serve`"""
+    build(c)
+    serve(c)
+
+@task
+def preview(c):
+    """Build production version of site"""
+    c.run('pelican -s publishconf.py')
+
+
+@task
+def publish(c):
+    """Publish to production via rsync"""
+    c.run('pelican -s publishconf.py')
+    c.run(
+        'rsync --delete --exclude ".DS_Store" -pthrvz -c '
+        '{} {production}:{dest_path}'.format(
+            CONFIG['deploy_path'].rstrip('/') + '/',
+            **CONFIG))
+


### PR DESCRIPTION
Get Pelican running and prove it can build a page. Aside from `requirements.txt` and `content/pages/home.md`, all new files are auto-generated by `pelican-quickstart`. In particular, please note the documentation I've added in `README.md`.

This is still using the default theme, which looks like [Pelican's blog](https://blog.getpelican.com/). We can leave it like this for now unless it gets in the way of us clearly seeing what we're doing. It does have space for "links" and "social media" via the config file, so it might be interesting to at least look at whether those are plumbed together in any interesting ways that we want to keep.